### PR TITLE
Correcting duplicate ISO Code

### DIFF
--- a/lib/netsuite/support/country.rb
+++ b/lib/netsuite/support/country.rb
@@ -69,7 +69,7 @@ module NetSuite
         'EC' => '_ecuador',
         'EG' => '_egypt',
         'SV' => '_elSalvador',
-        'GU' => '_equatorialGuinea',
+        'GQ' => '_equatorialGuinea',
         'ER' => '_eritrea',
         'EE' => '_estonia',
         'ET' => '_ethiopia',


### PR DESCRIPTION
The code 'GU' appears in the list twice. The proper code for Equatorial Guinea is GQ instead of GU.
